### PR TITLE
Fixed ONNX export

### DIFF
--- a/hypergan/gans/standard_gan.py
+++ b/hypergan/gans/standard_gan.py
@@ -36,7 +36,7 @@ class StandardGAN(BaseGAN):
         self.x = self.inputs.next()
 
     def build(self):
-        torch.onnx.export(self.generator, torch.randn(*self.latent.z.shape, device='cuda'), "generator.onnx", verbose=True, input_names=["latent"], output_names=["generator"])
+        torch.onnx.export(self.generator, self.latent.next(), "generator.onnx", verbose=True, input_names=["latent"], output_names=["generator"], opset_version=11)
 
     def required(self):
         return "generator".split()


### PR DESCRIPTION
## Description

When using `torch.randn` as the latent, PyTorch is unable to trace the model correctly, which leads to an ONNX model with no latent input. Using the actual `latent.next()` function solves this issue. Also, PyTorch uses version 9 of the ONNX opset by default, which leads to inconsistencies between the output generated by PyTorch and the ONNX model. Using version 11 fixes this.

## Changes

ONNX opset 11 requires PyTorch 1.3.0 or later.
